### PR TITLE
Check for bugs

### DIFF
--- a/Objects/Board.go
+++ b/Objects/Board.go
@@ -7,5 +7,8 @@ type Board struct {
 }
 
 func (b *Board) Set(pos Position, cell byte) {
+	if pos.Y < 0 || pos.Y >= b.Height || pos.X < 0 || pos.X >= b.Width {
+		return
+	}
 	b.Brd[pos.Y][pos.X] = cell
 }

--- a/Objects/Game.go
+++ b/Objects/Game.go
@@ -261,33 +261,25 @@ func (g *Game) printBoard() {
 	}
 }
 func (g *Game) spawnPieces() {
-	go func() {
-		for {
-			shapes := []Shape{Shape1, Shape2, Shape3, Shape4, Shape5, Shape6, Shape7, Shape8, Shape9}
-			colors := []Color{{Red}, {Green}, {Yellow}, {Blue}, {Purple}, {Orange}, {Brown}}
-			rand.Seed(time.Now().UnixNano())
-			randomShape := shapes[rand.Intn(len(shapes))]
-			randomColor := colors[rand.Intn(len(colors))]
-			randomX := rand.Intn(g.GameBoard.Width-4) + 1 // -4 for 3-wide shape + right wall, +1 to avoid left wall
-			piece := &Piece{
-				Position: Position{X: randomX, Y: 0},
-				shp:      randomShape,
-				color:    randomColor,
-			}
-			g.SpawnPiece(piece.shp, piece.Position, piece.color)
-			time.Sleep(time.Second * 2) //change this to 4 seconds
-		}
-	}()
+	shapes := []Shape{Shape1, Shape2, Shape3, Shape4, Shape5, Shape6, Shape7, Shape8, Shape9}
+	colors := []Color{{Red}, {Green}, {Yellow}, {Blue}, {Purple}, {Orange}, {Brown}}
+	rand.Seed(time.Now().UnixNano())
+	randomShape := shapes[rand.Intn(len(shapes))]
+	randomColor := colors[rand.Intn(len(colors))]
+	randomX := rand.Intn(g.GameBoard.Width-4) + 1 // -4 for 3-wide shape + right wall, +1 to avoid left wall
+	piece := &Piece{
+		Position: Position{X: randomX, Y: 0},
+		shp:      randomShape,
+		color:    randomColor,
+	}
+	g.SpawnPiece(piece.shp, piece.Position, piece.color)
 }
 
 func (g *Game) RotatePiece() {
-	if g.ActivePiece.rotated {
-		// g.ActivePiece.Rotate()
-		// g.ActivePiece.rotated = false
-	} else {
-		g.ActivePiece.Rotate()
-		g.ActivePiece.rotated = true
+	if g.ActivePiece == nil {
+		return
 	}
+	g.ActivePiece.Rotate()
 }
 
 func (g *Game) checkForLoss() {
@@ -339,16 +331,20 @@ func (g *Game) GetKeyPressed() {
 }
 
 func (g *Game) loop() {
-	g.spawnPieces()
+	ticker := time.NewTicker(time.Millisecond * 16)
+	spawnTicker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+	defer spawnTicker.Stop()
 	for g.isRunning {
-		g.Render()
-		g.UpdatePiece()
-		g.Update()
-		g.removeCompletedRow()
-		g.checkForLoss()
-		time.Sleep(time.Millisecond * 16)
-		// g.KeyPressed()
-		// g.GetKeyPressed()
-
+		select {
+		case <-ticker.C:
+			g.Render()
+			g.UpdatePiece()
+			g.Update()
+			g.removeCompletedRow()
+			g.checkForLoss()
+		case <-spawnTicker.C:
+			g.spawnPieces()
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func newGame(width, height int) *Objects.Game {
 			Height: height,
 			Brd:    make([][]byte, height),
 		},
+		PressedKey: make(chan byte, 1),
 	}
 }
 


### PR DESCRIPTION
Add bounds checks to `Board.Set` and rework game loop with tickers to prevent panics and data races.

The previous implementation used a goroutine with `time.Sleep` for piece spawning, which could lead to data races with the main game loop. This change moves piece spawning into the main loop, driven by a dedicated ticker, ensuring synchronized updates and preventing race conditions. Additionally, `Board.Set` now includes bounds checks to prevent out-of-range panics when pieces interact with board edges.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e357a61-9020-49cf-aa2c-30bf7d3d44c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e357a61-9020-49cf-aa2c-30bf7d3d44c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

